### PR TITLE
fix: Schedule the dap.run call

### DIFF
--- a/lua/debugpy.lua
+++ b/lua/debugpy.lua
@@ -104,7 +104,7 @@ M.adapter = {
 ---Function to run the debugger with a complete configuration. The default
 ---implementation calls `dap.run`.
 function M.run(final_config)
-	dap.run(final_config)
+  vim.schedule(function() dap.run(final_config) end)
 end
 
 function M.configure(subcommand, ...)


### PR DESCRIPTION
**Why** is the change needed?

To avoid race conditions where the `vim.notify` call inside of
`nvim-dap` causes the debugger to error out.

**How** is the need addressed?

-   Wrap the `dap.run` call with `vim.schedule`