### PR TITLE
Use the (no longer) new neovim 0.8 API for checkhealth

### DIFF
--- a/lua/debugpy/health.lua
+++ b/lua/debugpy/health.lua
@@ -1,17 +1,16 @@
 -- Health check implementation for debugpy.nvim
 local M = {}
 
-local health = require 'health'
 local command = require('debugpy').adapter.executable.command
 
 local function check_dap()
 	local success = pcall(require, 'dap')
 
 	if success then
-		health.report_ok "Plugin 'nvim-dap' found"
+		vim.health.ok "Plugin 'nvim-dap' found"
 	else
-		health.report_error "Plugin 'nvim-dap' not found"
-		health.report_info 'Official nvim-dap website: https://github.com/mfussenegger/nvim-dap'
+		vim.health.error "Plugin 'nvim-dap' not found"
+		vim.health.info 'Official nvim-dap website: https://github.com/mfussenegger/nvim-dap'
 	end
 
 	return success
@@ -20,11 +19,11 @@ end
 local function check_python()
 	local success = vim.fn.executable(command) ~= 0
 	if success then
-		health.report_ok(string.format("Executable '%s' found", command))
+		vim.health.ok(string.format("Executable '%s' found", command))
 	else
-		health.report_error(string.format("Executable '%s' not found", command))
-		health.report_warn 'Skipping check for debugpy module'
-		health.report_info 'See debugpy.adapter.executable on how to set your Python executable'
+		vim.health.error(string.format("Executable '%s' not found", command))
+		vim.health.warn 'Skipping check for debugpy module'
+		vim.health.info 'See debugpy.adapter.executable on how to set your Python executable'
 		return
 	end
 	return success
@@ -40,15 +39,15 @@ local function check_debugpy()
 		'from importlib.util import find_spec as fs; exit(0 if fs("debugpy") else 1)'
 	}
 	if vim.v.shell_error == 0 then
-		health.report_ok "Python module 'debugpy' found"
+		vim.health.ok "Python module 'debugpy' found"
 	else
-		health.report_error "Python module 'debugpy' not found"
-		health.report_info 'Official debugpy website: https://github.com/microsoft/debugpy'
+		vim.health.error "Python module 'debugpy' not found"
+		vim.health.info 'Official debugpy website: https://github.com/microsoft/debugpy'
 	end
 end
 
 function M.check()
-	health.report_start 'Debugpy.nvim'
+	vim.health.start 'Debugpy.nvim'
 
 	check_dap()
 	check_python()


### PR DESCRIPTION
`:checkhealth` has not been working properly since neovim v0.8 due to updates in the core apis. I suggest to fix by updating to the new apis.

If you feel it is necessary, it would be relatively easy to support both api's. I don't personally think it should be necessary, but I'll oblige if you disagree.